### PR TITLE
Update nuxt config to proxy requests; Remove CORS headers from nginx config

### DIFF
--- a/.ddev/nginx_full/nginx-site.conf
+++ b/.ddev/nginx_full/nginx-site.conf
@@ -8,28 +8,6 @@ server {
     listen 80 default_server;
     listen 443 ssl default_server;
 
-    # If the origin doesn't match, we won't send *any* access control headers back because none of the 
-    # variables will be set.
-    #
-    # This is convenient instead of map because we can group all the header values together instead of
-    # searching through the NGiNX config for them. 
-    # 
-    # Also, all the values are used again in the preflight response.
-    if ($http_origin ~ ^https?://(.*\.)?dot-all-2022.fostercommerce.test(:\d+)?$) {
-        set $allow_origin $http_origin;
-        set $expose_headers "Content-Encoding,Length,Authorization";
-        set $allow_methods "GET, POST, DELETE, OPTIONS, HEAD";
-        set $allow_headers "Authorization, Origin, x-csrf-token, Cache-Control, X-Requested-With, Content-Type, Accept";
-        set $allow_credentials "true";
-    }
-
-    # Always return these CORS headers.
-    # 
-    # Not really necessary for GET requests.
-    add_header "Access-Control-Allow-Origin" $allow_origin always;
-    add_header 'Access-Control-Expose-Headers' $expose_headers always;
-    add_header "Access-Control-Allow-Credentials" $allow_credentials always;
-
     root /var/www/html/web;
 
     ssl_certificate /etc/ssl/certs/master.crt;
@@ -47,21 +25,6 @@ server {
     location / {
         absolute_redirect off;
         try_files $uri $uri/ /index.php?$query_string;
-
-        # For preflight requests, tell the client everything it needs to know.
-        if ($request_method = OPTIONS ) {
-            # The headers need to be added here again because: 
-            # 
-            # > These directives are inherited from the previous configuration level if and only if there are no add_header directives defined on the current level. 
-            # 
-            # From: http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
-            add_header "Access-Control-Allow-Origin" $allow_origin always;
-            add_header "Access-Control-Allow-Methods" $allow_methods always;
-            add_header "Access-Control-Allow-Headers" $allow_headers always;
-            add_header 'Access-Control-Expose-Headers' $expose_headers always;
-            add_header "Access-Control-Allow-Credentials" $allow_credentials always;
-            return 200;
-        }
     }
 
     # pass the PHP scripts to FastCGI server listening on socket

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -53,10 +53,12 @@ export default {
   axios: {
     proxyHeaders: false,
     credentials: true,
-    // proxy: true,
+    proxy: true,
   },
 
   proxy: {
+		'/api': { target: process.env.CRAFT_BASE_URL, pathRewrite: { '^/api': '' } },
+		'/graphql': { target: process.env.CRAFT_BASE_URL + '/api', pathRewrite: { '^/graphql': '' } },
     '/*sitemap.xml': process.env.CRAFT_BASE_URL,
     '/*sitemap.xsl': process.env.CRAFT_BASE_URL,
     '/sitemap.xml': process.env.CRAFT_BASE_URL,
@@ -82,7 +84,7 @@ export default {
       });
     },
   },
-  
+
   env: {
     currentEnv: process.env.CRAFT_ENVIRONMENT || 'dev'
   },
@@ -92,14 +94,12 @@ export default {
     graphQLBearerToken: process.env.CRAFT_API_TOKEN,
     axios: {
       retry: 4,
-      baseURL: process.env.CRAFT_BASE_URL,
     }
   },
   publicRuntimeConfig: {
     baseURL: process.env.CRAFT_BASE_URL,
     axios: {
       retry: true,
-      browserBaseURL: process.env.CRAFT_BASE_URL,
     }
   }
 }

--- a/src/pages/catalog/_slug.vue
+++ b/src/pages/catalog/_slug.vue
@@ -4,7 +4,7 @@
 	export default {
 		async asyncData({$axios, route}) {
 
-			const { data } = await $axios.$post('/api',
+			const { data } = await $axios.$post('/graphql',
 				{
 					query: print(Product), variables: { slug: route.params.slug }
 				},

--- a/src/plugins/api.js
+++ b/src/plugins/api.js
@@ -35,7 +35,7 @@ const api = ($config, store) => {
 	const get = async (action, config = {}) => {
 		const {
 			data
-		} = await axios.get(`${$config.baseURL}${action}`, withDefaultConfig({config}), );
+		} = await axios.get(`/api${action}`, withDefaultConfig({config}), );
 
 		return data;
 	}
@@ -47,14 +47,14 @@ const api = ($config, store) => {
 			...postData,
 		};
 
-		// console.log('stringified form data: ', stringify(data));
+		console.log('post', action)
 
-		const response = await axios.post($config.baseURL,
+		const response = await axios.post(`/api`,
 			stringify(data),
 			withDefaultConfig(config),
 
 		)
-		// console.log('postAction form response', response);
+
 		return response.data
 	}
 
@@ -67,21 +67,21 @@ const api = ($config, store) => {
 				qty: item.qty,
 			};
 
-			return await postAction('commerce/cart/update-cart', data);
+			return await postAction('/commerce/cart/update-cart', data);
 		},
 		updateQty: async (item) => {
 			const data = {
 				lineItems: {[item.itemId]: {'qty': item.qty}}
 			};
 
-			return await postAction('commerce/cart/update-cart', data)
+			return await postAction('/commerce/cart/update-cart', data)
 		},
 		removeItem: async (item) => {
 			const data = {
 				lineItems: {[item.itemId]: {'remove': true}}
 			};
 
-			return await postAction('commerce/cart/update-cart', data);
+			return await postAction('/commerce/cart/update-cart', data);
 		},
 		getCart: async () => {
 			return await get('/actions/commerce/cart/get-cart');
@@ -90,7 +90,7 @@ const api = ($config, store) => {
 			const data = {
 				couponCode: item.coupon
 			};
-			return await postAction('commerce/cart/update-cart', data);
+			return await postAction('/commerce/cart/update-cart', data);
 		}
 	}
 };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -66,7 +66,7 @@ export const actions = {
 	async queryAPI({ commit }, { name, variables, params }) {
 		const query = await import(`@/queries/${name}.gql`).then((module) => module.default);
 		return await this.$axios.$post(
-			'/api',
+			'/graphql',
 			{
 				query: print(query),
 				variables,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -49,7 +49,7 @@ export const actions = {
 	async nuxtServerInit({ commit, dispatch }) {
 		// Fetch the settings entry to get the sites global navigation
 		const query = await import('@/queries/EntrySettings.gql').then((module) => module.default);
-		const { data: queryData, queryErrors } = await this.$axios.$post('/api', {
+		const { data: queryData, queryErrors } = await this.$axios.$post('/graphql', {
 			query: print(query),
 		});
 		commit('setPrimaryNav', queryData.entry.primaryNavigation);


### PR DESCRIPTION
- Adds nuxt config to proxy requests:
  - `/api` to `CRAFT_BASE_URL`;
  - `/graphql` to `CRAFT_BASE_URL/api`.
- Updates axios config to remove baseUrl;
  - axios config's baseUrl is applied to both frontend and nuxt's server. So removing the baseUrl ensures that the any use of $axios is consistent between frontend/backend. 
- Updates api.js to remove the baseUrl usage;
- Updates gql calls to point at `/graphql`. 
  - Note: these calls are also proxied.