### PR TITLE
Fix routing for graphql; Update api functions

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -19,5 +19,5 @@
  */
 
 return [
-    'api' => 'graphql/api',
+    'graphql' => 'graphql/api',
 ];

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -57,8 +57,11 @@ export default {
   },
 
   proxy: {
+		// This will proxy https://<nuxt host>/api/... to https://craft host/... _without_ the /api part.
 		'/api': { target: process.env.CRAFT_BASE_URL, pathRewrite: { '^/api': '' } },
-		'/graphql': { target: process.env.CRAFT_BASE_URL + '/api', pathRewrite: { '^/graphql': '' } },
+		// This will proxy https://<nuxt host>/graphql to https://<craft host>/graphql. The proxy module will include
+		// the /graphql path unless it's explicitly removed with pathRewrite.
+		'/graphql': { target: process.env.CRAFT_BASE_URL },
     '/*sitemap.xml': process.env.CRAFT_BASE_URL,
     '/*sitemap.xsl': process.env.CRAFT_BASE_URL,
     '/sitemap.xml': process.env.CRAFT_BASE_URL,

--- a/src/components/views/PagesCollection.vue
+++ b/src/components/views/PagesCollection.vue
@@ -21,7 +21,7 @@
 				categories.push(parseInt(category.id));
 			}
 
-			const products = await this.$api.fetchCatalog(
+			const products = await this.$api.graphqlQuery(
 				ProductsCatalog,
 				{ categories }
 			);

--- a/src/pages/_.vue
+++ b/src/pages/_.vue
@@ -4,13 +4,14 @@
 
 	import PagesGeneral from '@/components/views/PagesGeneral';
 	import PagesCollection from '@/components/views/PagesCollection';
+	import EntriesPages from '@/queries/EntriesPages.gql';
 
 	export default {
 		components: {
 			PagesGeneral,
 			PagesCollection
 		},
-		async asyncData({ route, store }) {
+		async asyncData({ $api, route }) {
 			// Check for Craft Live Preview params
 			let previewParams = null;
 			if (route.query['x-craft-live-preview']) {
@@ -21,14 +22,14 @@
 			}
 
 			// Call the query API method to get the data from Craft
-			const { data: queryData } = await store.dispatch('queryAPI', {
-				name: 'EntriesPages',
-				variables: {
+			const {data: queryData} = await $api.graphqlQuery(
+				EntriesPages,
+				{
 					limit: 1,
 					uri: route.params.pathMatch,
 				},
-				params: previewParams,
-			});
+				previewParams
+			);
 
 			return {
 				entry: queryData?.entries[0],

--- a/src/pages/catalog/_slug.vue
+++ b/src/pages/catalog/_slug.vue
@@ -2,19 +2,11 @@
 	import { print } from 'graphql';
 	import Product from '@/queries/Product.gql';
 	export default {
-		async asyncData({$axios, route}) {
+		async asyncData({$api, route}) {
 
-			const { data } = await $axios.$post('/graphql',
-				{
-					query: print(Product), variables: { slug: route.params.slug }
-				},
-				{
-					headers: {
-						'Content-Type': 'application/json',
-						Accept: 'application/json'
-					}
-				});
-			return{
+			const { data } = await $api.graphqlQuery(Product, { slug: route.params.slug });
+
+			return {
 				product: data.product,
 				variants: data.variants,
 				selectedVariant: data.variants[0]

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,6 +1,8 @@
 <script>
+	import EntryHome from '@/queries/EntryHome.gql';
+
 	export default {
-		async asyncData({ route, store }) {
+		async asyncData({ $api, route }) {
 			// Check for Craft Live Preview params
 			let previewParams = null;
 			if (route.query['x-craft-live-preview']) {
@@ -11,13 +13,11 @@
 			}
 
 			// Call the query API method to get the data from Craft
-			const { data: queryData } = await store.dispatch('queryAPI', {
-				name: 'EntryHome',
-				variables: {
-					limit: 1
-				},
-				params: previewParams,
-			});
+			const {data: queryData} = await $api.graphqlQuery(
+				EntryHome,
+				{limit: 1},
+				previewParams,
+			);
 
 			return {
 				entry: queryData?.entry,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -49,32 +49,8 @@ export const actions = {
 	async nuxtServerInit({ commit, dispatch }) {
 		// Fetch the settings entry to get the sites global navigation
 		const query = await import('@/queries/EntrySettings.gql').then((module) => module.default);
-		const { data: queryData, queryErrors } = await this.$axios.$post('/graphql', {
-			query: print(query),
-		});
+		const {data: queryData} = await this.$api.graphqlQuery(query);
 		commit('setPrimaryNav', queryData.entry.primaryNavigation);
-	},
-	/**
-	 *
-	 * Imports a GQL file to be used for a fetch request, then
-	 * querying the GraphQL API with the relevant query string.
-	 * Utilizes graphql/language/printer to convert from AST to a string for Craft.
-	 * @param {dispatch, commit, state} param0
-	 * @param {name, variables, params}
-	 * @returns
-	 */
-	async queryAPI({ commit }, { name, variables, params }) {
-		const query = await import(`@/queries/${name}.gql`).then((module) => module.default);
-		return await this.$axios.$post(
-			'/graphql',
-			{
-				query: print(query),
-				variables,
-			},
-			{
-				params,
-			}
-		);
 	},
 	setCsrfToken({ commit }, csrfData) {
 		commit('setCsrfToken', csrfData);


### PR DESCRIPTION
- *NB:* Changes the graphql route in Craft from `/api` to `/graphql` to avoid confusion;
- Updates the proxy routes in nuxt config. Added some comments there too;
- Restored the `postAction` function to its previous state so that it only works for posting Craft actions;
- Added the `graphqlQuery` function to api.js and updated all gql queries in the frontend to use that function instead.

```
await $api.graphqlQuery(MyGqlQuery, { /* variables */}, { /* params like preview tokens */});
```

- Removed the `queryAPI` function from the store.
