### PR TITLE
Only allow unauthorized TLS in dev environment; Use nuxt's axios instance

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,3 +1,5 @@
+import https from 'https';
+
 export default {
   // Target: https://go.nuxtjs.dev/config-target
   target: 'server',
@@ -54,6 +56,9 @@ export default {
     proxyHeaders: false,
     credentials: true,
     proxy: true,
+		httpsAgent: new https.Agent({
+			rejectUnauthorized: process.env.CRAFT_ENVIRONMENT !== 'dev',
+		}),
   },
 
   proxy: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,7 @@
 import https from 'https';
 
+let isDev = process.env.CRAFT_ENVIRONMENT === 'dev';
+
 export default {
   // Target: https://go.nuxtjs.dev/config-target
   target: 'server',
@@ -57,16 +59,16 @@ export default {
     credentials: true,
     proxy: true,
 		httpsAgent: new https.Agent({
-			rejectUnauthorized: process.env.CRAFT_ENVIRONMENT !== 'dev',
+			rejectUnauthorized: !isDev,
 		}),
   },
 
   proxy: {
 		// This will proxy https://<nuxt host>/api/... to https://craft host/... _without_ the /api part.
-		'/api': { target: process.env.CRAFT_BASE_URL, pathRewrite: { '^/api': '' } },
+		'/api': { target: process.env.CRAFT_BASE_URL, pathRewrite: { '^/api': '' }, secure: !isDev},
 		// This will proxy https://<nuxt host>/graphql to https://<craft host>/graphql. The proxy module will include
 		// the /graphql path unless it's explicitly removed with pathRewrite.
-		'/graphql': { target: process.env.CRAFT_BASE_URL },
+		'/graphql': { target: process.env.CRAFT_BASE_URL, secure: !isDev },
     '/*sitemap.xml': process.env.CRAFT_BASE_URL,
     '/*sitemap.xsl': process.env.CRAFT_BASE_URL,
     '/sitemap.xml': process.env.CRAFT_BASE_URL,

--- a/src/plugins/api.js
+++ b/src/plugins/api.js
@@ -20,9 +20,6 @@ const api = ($config, store) => {
 				Accept: 'application/json',
 				...requestConfig.headers,
 			},
-			httpsAgent: new https.Agent({
-				rejectUnauthorized: false,
-			}),
 		};
 	}
 

--- a/src/plugins/api.js
+++ b/src/plugins/api.js
@@ -1,15 +1,15 @@
-import https from 'https';
 import axios from 'axios';
 import { stringify } from 'qs';
 import { print } from 'graphql';
 
-const api = ($config, store) => {
+const api = ({$axios}, $config, store) => {
 	/**
 	 * Utility to add default request config to requests, such as adding commonly used headers.
 	 *
 	 * @param {*} requestConfig custom request config to be merged with the default config.
 	 * @returns merged request config.
 	 */
+
 	const withDefaultConfig = (requestConfig = {}) => {
 		return {
 			...requestConfig,
@@ -24,7 +24,7 @@ const api = ($config, store) => {
 	}
 
 	const get = async (action, config = {}) => {
-		const { data } = await axios.get(`/api${action}`, withDefaultConfig({ config }));
+		const { data } = await $axios.get(`/api${action}`, withDefaultConfig({ config }));
 
 		return data;
 	}
@@ -36,7 +36,7 @@ const api = ($config, store) => {
 			...postData,
 		};
 
-		const response = await axios.post(`/api`,
+		const response = await $axios.post(`/api`,
 			stringify(data),
 			withDefaultConfig(config),
 
@@ -55,7 +55,7 @@ const api = ($config, store) => {
 				params
 			};
 
-			const response = await axios.post(`/graphql`,
+			const response = await $axios.post(`/graphql`,
 				data,
 				withDefaultConfig({
 					headers: {
@@ -109,5 +109,5 @@ const api = ($config, store) => {
 };
 
 export default ({ app, $config, store }, inject) => {
-	inject('api', api($config, store));
+	inject('api', api(app, $config, store));
 };

--- a/src/plugins/axios.js
+++ b/src/plugins/axios.js
@@ -4,12 +4,5 @@ export default function ({
     $axios,
     store
 }) {
-    const agent = new https.Agent({
-        rejectUnauthorized: false
-    });
-    $axios.onRequest(config => {
-        if (process.env.currentEnv === 'dev') {
-            config.httpsAgent = agent;
-        }
-    });
+	// Any extra runtime config.
 }

--- a/src/store/cart.js
+++ b/src/store/cart.js
@@ -11,7 +11,7 @@ export const state = () => ({
     number: null,
   },
   cartErrors: []
- 
+
 });
 
 export const getters = {
@@ -20,7 +20,7 @@ export const getters = {
    */
   getItems(state) {
     return state.items;
-  },  
+  },
   /**
    * Get the current cart id
    */
@@ -145,14 +145,14 @@ export const actions = {
     } catch (error) {
       handleError(commit, error)
     }
-    
-    
+
+
   },
   /**
    * Remove an item entirely from the cart
    */
   async removeItem({ commit, dispatch }, item) {
-   
+
     try {
        const {
          cart
@@ -194,7 +194,7 @@ export const actions = {
         return true
       }
 
-      
+
     } catch (error) {
       handleError(commit, error)
       return false


### PR DESCRIPTION
- Moves axios config to nuxt.config.js;
- Adds `secure: false` for dev environments;
- Fixes api.js so that it uses Nuxt's configured axios instance instead of a new one.